### PR TITLE
Add the 'No Shenanigans' response header for '/todos/*' endpoints

### DIFF
--- a/src/server/webapp.js
+++ b/src/server/webapp.js
@@ -20,6 +20,12 @@ if (process.env.NODE_ENV !== 'production') {
   app.use('/static', express.static(staticPath));
 }
 
+// Add the "No Shenanigans" header to all responses under the "/todos" path
+app.use('/todos', (request, response, next) => {
+  response.set('X-Shenanigans', 'None');
+  next();
+});
+
 // Mount application routes
 routes(app);
 


### PR DESCRIPTION
Fixes #7
